### PR TITLE
Minor adjustments

### DIFF
--- a/ArchiveGenerator.sh
+++ b/ArchiveGenerator.sh
@@ -13,32 +13,44 @@
 # Function: Executes the script.                                        #
 #########################################################################
 function main {
-	# Define archive name.
-	archive="hadoop-pipeline_$(date "+%Y-%m-%d").tar"
+	# Define archive names.
+	archivePrefix="hadoop-pipeline_$(date "+%Y-%m-%d")"
+	completeArchive="${archivePrefix}.tar"
+	toolsOnlyGzipArchive="${archivePrefix}_tools_only.tar.gz"
 	
-	# Generate file that will store the content of the archive.
-	date "+# VERSION: %Y-%m-%d" > external_files.txt;
-	
-	# Create tar with (almost) all files and store output in the content file.
-	tar --exclude .DS_Store --exclude hadoop-pipeline-application/src/test/resources/character_replacer/ \
-	-cvf ${archive} \
-	hadoop-pipeline-application/src/test/resources/* \
-	hadoop-pipeline-halvade-testing/data/* \
-	hadoop-pipeline-tools/* \
-	archive_files_info.md \
-	2>> external_files.txt
-	
-	# Add an extra line defining that the content file is also added.
-	echo "a archive_files.txt" >> external_files.txt
-	
-	# Create a copy of the content file (with a different name) that will be added to the archive.
-	cp external_files.txt archive_files.txt
-	
-	# Add the content file to the archive.
-	tar -rf ${archive} archive_files.txt
-	
-	# Gzip the archive.
-	gzip ${archive}
+	# Only creates the new archives if neither exist yet.
+	if [ -f "${completeArchive}.gz" ] || [ -f "${toolsOnlyGzipArchive}" ]
+	then
+		echo "Archive(s) with the current date already exist. Please (re)move it/them before creating new ones."
+	else
+		# Generate file that will store the content of the archive.
+		date "+# VERSION: %Y-%m-%d" > external_files.txt;
+		
+		# Create tar with (almost) all files and store output in the content file.
+		tar --exclude .DS_Store --exclude hadoop-pipeline-application/src/test/resources/character_replacer/ \
+		-cvf ${completeArchive} \
+		hadoop-pipeline-application/src/test/resources/* \
+		hadoop-pipeline-halvade-testing/data/* \
+		hadoop-pipeline-tools/* \
+		archive_files_info.md \
+		2>> external_files.txt
+		
+		# Add an extra line defining that the content file is also added.
+		echo "a archive_files.txt" >> external_files.txt
+		
+		# Create a copy of the content file (with a different name) that will be added to the archive.
+		cp external_files.txt archive_files.txt
+		
+		# Add the content file to the archive.
+		tar -rf ${completeArchive} archive_files.txt
+		
+		# Gzip the archive.
+		gzip ${completeArchive}
+		
+		# Creates an archive with the tools only.
+		tar --exclude .DS_Store -czf ${toolsOnlyGzipArchive} \
+		hadoop-pipeline-tools/*
+	fi
 }
 
 main

--- a/README.md
+++ b/README.md
@@ -26,7 +26,16 @@ Before using the tool, be sure that the following has been done:
 	* Be sure that the given contig name, start position and end position are valid compared to the reference sequence data.
 	* The bed file should be UTF-8 compliant.
 
-* A samplesheet csv file is present with information about the input data. Note that this file will be used for comparison with the last directory of each input file, so be sure that all input folders that will be digested are mentioned in this csv file. Be sure that all used samples are mentioned in the samplesheet csv file (and only these)! If the samplesheet contains information about more samples than used within the job, the other samples will still be added using an @RG tag to each created output file by the job (this to reduce application running time).
+* A samplesheet csv file is present with information about the input data. Note that this file will be used for comparison with the last directory of each input file, so be sure that all input folders that will be digested are mentioned in this csv file. Be sure that all used samples are mentioned in the samplesheet csv file (and only these)! If the samplesheet contains information about more samples than used within the job, the other samples will still be added using an @RG tag to each created output file by the job (this to reduce application running time). While this file can contain all sorts of information, it should at least contain columns with the following headers:
+	
+	* externalSampleID
+	* sequencer
+	* sequencingStartDate
+	* run
+	* flowcell
+	* lane
+
+	The actual column order (or whether there are columns in between) does not matter.
 
 ### Preparing the halvade upload tool
 1. Create a local clone of [https://github.com/ddcap/halvade.git](https://github.com/ddcap/halvade.git).

--- a/README.md
+++ b/README.md
@@ -218,3 +218,7 @@ I get an error similar to that shown below.
 
 __Solution:__
 Try increasing the time before Hadoop ends a mapper/reducer if it has not contacted the context yet. This can be done by increasing the `mapreduce.task.timeout` value (either in the cluster config files or by using `-D`).
+
+## Developer notes
+
+A class UML design was generated using the [Eclipse](https://eclipse.org/) plugin from [ObjectAid](http://www.objectaid.com/). This design can be found on the [molgenis downloads page](https://molgenis26.target.rug.nl/downloads/hadoop/). Do note that the image was software-generated, so no guarantee is given about the correctness of the image. Nevertheless, it should allow for a good initial overview of how the created Hadoop application tool functions.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ The `info.xml` file contains information of all tools present in the archive and
 	
 		hdfs dfs -get /hdfs/path/to/output/folder/ /local/folder/to/copy/results/to/
 
+## Developer notes
+
+A class UML design was generated using the [Eclipse](https://eclipse.org/) plugin from [ObjectAid](http://www.objectaid.com/). This design can be found on the [molgenis downloads page](https://molgenis26.target.rug.nl/downloads/hadoop/). Do note that the image was software-generated, so no guarantee is given about the correctness of the image. Nevertheless, it should allow for a good initial overview of how the created Hadoop application tool functions.
 
 ## Troubleshooting
 
@@ -218,7 +221,3 @@ I get an error similar to that shown below.
 
 __Solution:__
 Try increasing the time before Hadoop ends a mapper/reducer if it has not contacted the context yet. This can be done by increasing the `mapreduce.task.timeout` value (either in the cluster config files or by using `-D`).
-
-## Developer notes
-
-A class UML design was generated using the [Eclipse](https://eclipse.org/) plugin from [ObjectAid](http://www.objectaid.com/). This design can be found on the [molgenis downloads page](https://molgenis26.target.rug.nl/downloads/hadoop/). Do note that the image was software-generated, so no guarantee is given about the correctness of the image. Nevertheless, it should allow for a good initial overview of how the created Hadoop application tool functions.

--- a/external_files.txt
+++ b/external_files.txt
@@ -1,4 +1,4 @@
-# VERSION: 2016-01-08
+# VERSION: 2016-02-02
 a hadoop-pipeline-application/src/test/resources/bed_files
 a hadoop-pipeline-application/src/test/resources/bed_files/chr1_20000000-21000000.bed
 a hadoop-pipeline-application/src/test/resources/bed_files/line_contig-start-end-name_normal-end.bed

--- a/hadoop-pipeline-application/.gitignore
+++ b/hadoop-pipeline-application/.gitignore
@@ -5,3 +5,6 @@ src/test/resources/*
 !src/test/resources/character_replacer/
 .classpath
 .project
+
+#directory name that can be used to locally create UML diagrams
+uml-diagrams/


### PR DESCRIPTION
Updated the readme, the ArchiveGenerator now also creates an archive with only the tools (end-user only needs these anyway so saves a lot of download time) & adjusted the .gitignore to allow for a directory which can be used for storing UML designs locally.
